### PR TITLE
Change on the file extension regex

### DIFF
--- a/lib/rack/jekyll/helpers.rb
+++ b/lib/rack/jekyll/helpers.rb
@@ -2,7 +2,7 @@ module Rack
   class Jekyll
     def mime(path_info)
       if path_info !~ /html$/i
-        ext = $1 if path_info =~ /(\.\S+)$/
+        ext = $1 if path_info =~ /(\.[\S&&[^.]]+)$/
         Mime.mime_type((ext.nil? ? ".html" : ext))
       else
         Mime.mime_type(".html")

--- a/lib/rack/jekyll/test.rb
+++ b/lib/rack/jekyll/test.rb
@@ -7,7 +7,7 @@ module Rack
   class Jekyll
     class Test 
       def initialize
-        @files = %w{_fake/ _fake/index.html _fake/3/2/1/helloworld/index.html _fake/css/test.css _fake/js/test.js}
+        @files = %w{_fake/ _fake/index.html _fake/3/2/1/helloworld/index.html _fake/css/test.css _fake/js/test.js _fake/js/test.min.js}
         @mimes = Rack::Mime::MIME_TYPES.reject{|k,v|k=~%r{html?}}.map{|k,v|%r{#{k.gsub('.','\.')}$}i}
       end
     
@@ -35,7 +35,7 @@ module Rack
         end
       end
       def mime(path_info)
-        ext = $1 if path_info =~ /(\.\S+)$/
+        ext = $1 if path_info =~ /(\.[\S&&[^.]]+)$/
         Mime.mime_type((ext.nil? ? ".html" : ext))
       end
     end

--- a/spec/spec_rack-jekyll.rb
+++ b/spec/spec_rack-jekyll.rb
@@ -48,6 +48,11 @@ describe "Jekyll to Rack" do
     res = get(jekyll,"/js/test.js")
     res.headers["Content-Type"].should.equal "application/javascript"
   end
+  
+  it "should be application/javascript even when minified" do
+    res = get(jekyll,"/js/test.min.js")
+    res.headers["Content-Type"].should.equal "application/javascript"
+  end
 
   
 end

--- a/test/rack-jekyll.rb
+++ b/test/rack-jekyll.rb
@@ -26,6 +26,7 @@ class RackJekyllTest < Test::Unit::TestCase
     assert_equal(@request.get("/").headers["Content-Type"],"text/html")
     assert_equal(@request.get("/css/test.css").headers["Content-Type"],"text/css")
     assert_equal(@request.get("/js/test.js").headers["Content-Type"],"application/javascript")
+    assert_equal(@request.get("/js/test.min.js").headers["Content-Type"],"application/javascript")
   end
 
   def test_content_length


### PR DESCRIPTION
I changed the regex from/(.\S+)$/ to /(.[\S&&[^.]]+)$/, to prevent 
problems with files with dots in their names.

So it won't conflict with file names with `.` (dots) in their
names. For example: example.min.js will get only .js instead
of .min.js . 

It was causing minified files to break.
