### PR TITLE
bump Jekyll dependency to ~ 0.12.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,15 +2,13 @@ PATH
   remote: .
   specs:
     rack-jekyll (0.4.0)
-      jekyll (~> 0.11.0)
+      jekyll (~> 0.12.0)
       rack (~> 1.4.1)
 
 GEM
   remote: http://rubygems.org/
   specs:
     RedCloth (4.2.9)
-    albino (1.3.3)
-      posix-spawn (>= 0.3.6)
     bacon (1.1.0)
     builder (3.0.0)
     classifier (1.3.3)
@@ -23,28 +21,32 @@ GEM
       term-ansicolor (>= 1.0.4)
       treetop (>= 1.4.2)
     diff-lcs (1.1.3)
-    directory_watcher (1.4.1)
-    fast-stemmer (1.0.1)
-    jekyll (0.11.2)
-      albino (~> 1.3)
+    directory_watcher (1.5.1)
+    fast-stemmer (1.0.2)
+    jekyll (0.12.1)
       classifier (~> 1.3)
       directory_watcher (~> 1.1)
-      kramdown (~> 0.13)
+      kramdown (~> 0.14)
       liquid (~> 2.3)
       maruku (~> 0.5)
+      pygments.rb (~> 0.3.2)
     json_pure (1.7.3)
-    kramdown (0.13.6)
-    liquid (2.3.0)
-    maruku (0.6.0)
+    kramdown (0.14.2)
+    liquid (2.5.0)
+    maruku (0.6.1)
       syntax (>= 1.0.0)
     polyglot (0.3.3)
     posix-spawn (0.3.6)
+    pygments.rb (0.3.7)
+      posix-spawn (~> 0.3.6)
+      yajl-ruby (~> 1.1.0)
     rack (1.4.1)
     syntax (1.0.0)
     term-ansicolor (1.0.7)
     treetop (1.4.10)
       polyglot
       polyglot (>= 0.3.1)
+    yajl-ruby (1.1.0)
 
 PLATFORMS
   ruby

--- a/rack-jekyll.gemspec
+++ b/rack-jekyll.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
  s.require_paths = %w[lib]
  s.rubyforge_project = 'rack-jekyll'
  s.rubygems_version = '1.3.1'
- s.add_dependency 'jekyll', "~> 0.11.0"
+ s.add_dependency 'jekyll', "~> 0.12.0"
  s.add_dependency 'rack', "~> 1.4.1"
  s.add_development_dependency('bacon')
  s.platform = Gem::Platform::RUBY


### PR DESCRIPTION
Bumps Jekyll to the latest version on the 0.12 branch, which is 0.12.1.

Fixes #8
