### PR TITLE
Newly created files returning 404 when auto generating

### DIFF
--- a/lib/rack/jekyll.rb
+++ b/lib/rack/jekyll.rb
@@ -63,6 +63,9 @@ module Rack
       @request = Rack::Request.new(env)
       @response = Rack::Response.new
       path_info = @request.path_info
+      while @compiling
+        sleep 0.1
+      end
       @files = ::Dir[@path + "/**/*"].inspect if @files == "[]"
       if @files.include?(path_info)
         if path_info =~ /(\/?)$/
@@ -88,9 +91,6 @@ module Rack
       else
         status, body, path_info = ::File.exist?(@path+"/404.html") ? [404,file_info(@path+"/404.html")[:body],"404.html"] : [404,"Not found","404.html"]
         mime = mime(path_info)
-        while @compiling
-          sleep 0.1
-        end
 
         [status, {"Content-Type" => mime, "Content-length" => body.bytesize.to_s}, [body]]
       end


### PR DESCRIPTION
Rack::Jekyll has the `auto` option to regenerate the site when files changes. This works, but when a new file is added and auto generated the file list isn't updated so Rack::Jekyll returns a 404.

I've patched it to reload the file list after compilation of the site so 404's are not returned for existing files.
