### PR TITLE
Enabled dependency of jekyll 2.0

### DIFF
--- a/rack-jekyll.gemspec
+++ b/rack-jekyll.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
  s.require_paths = %w[lib]
  s.rubyforge_project = 'rack-jekyll'
  s.rubygems_version = '1.3.1'
- s.add_dependency 'jekyll', "~> 1.3"
+ s.add_dependency 'jekyll', "> 1.3"
  s.add_dependency 'rack', "~> 1.5.0"
  s.add_development_dependency('bacon')
  s.platform = Gem::Platform::RUBY


### PR DESCRIPTION
jekyll 2.0 is already released: http://jekyllrb.com/news/2014/05/06/jekyll-turns-2-0-0/

I fixed dependency of gemspec.
