### PR TITLE
Fixed 'auto' option for Jekyll > 2.0

### DIFF
--- a/lib/rack/jekyll.rb
+++ b/lib/rack/jekyll.rb
@@ -38,7 +38,7 @@ module Rack
                               .to_path
         puts "Auto-regenerating enabled: #{source} -> #{destination}"
 
-        Listen.to(source, :ignore => %r{#{Regexp.escape(destination)}}) do |modified, added, removed|
+        listener = Listen.to(source, :ignore => %r{#{Regexp.escape(destination)}}) do |modified, added, removed|
           @compiling = true
           t = Time.now.strftime("%Y-%m-%d %H:%M:%S")
           n = modified.length + added.length + removed.length
@@ -47,6 +47,7 @@ module Rack
           @files = ::Dir[@path + "/**/*"].inspect
           @compiling = false
         end
+        listener.start
       end
     end
 


### PR DESCRIPTION
Jekyll now uses a newer version of the Listen gem. The new gem doesn’t
support the old Listen syntax, and therefore the event never fires.
This fixes that by “starting” the listener.
