### PR TITLE
Show users a static page while the site is rendering

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -53,6 +53,7 @@ You need to generate pages and git-add pages and git-commit before you deploy yo
 ## Initialization Options
 
     :destination          - use the desintation path (default: _site)
+    :wait_page            - a page to display while pages are rendering
 
 
 *Example:*
@@ -68,6 +69,21 @@ It now can read the `_config.yml` file for destination path. Read [Jekyll Config
 ## 404 page
 
 You can create a new file: `404.html` with YAML Front Matter. See my [Heroku Demo 404](http://bry4n.heroku.com/show/me/404/)
+
+## Wait page
+
+You can create a custom HTML page to display while Jekyll is rendering the
+site.  Set the `:wait_page` initialization option to point to a file relative
+to the root of your Jekyll project.
+
+*Example:*
+
+    run Rack::Jekyll.new(:wait_page => "hold_on.html")
+
+Note that this page should be self-contained (no links to external CSS
+or JS).  It is also not a bad idea to add a `<meta http-equiv="refresh"
+content="60"/>` to the `head` section so that the page will periodically
+refresh itself and display the site once Jekyll has finished rendering.
 
 ## Contributors
 * adaoraul (Adão Raul)

--- a/lib/rack/jekyll.rb
+++ b/lib/rack/jekyll.rb
@@ -65,13 +65,16 @@ module Rack
                               .to_path
         puts "Auto-regenerating enabled: #{source} -> #{destination}"
 
-        Listen.to(source, :ignore => %r{#{Regexp.escape(destination)}}) do |modified, added, removed|
-          t = Time.now.strftime("%Y-%m-%d %H:%M:%S")
-          n = modified.length + added.length + removed.length
-          puts "[#{t}] regeneration: #{n = modified.length + added.length + removed.length} files changed"
-          process(site)
-          @files = ::Dir[@path + "/**/*"].inspect
+        listener = Listen.to(source, :ignore => %r{#{Regexp.escape(destination)}}) do |modified, added, removed|
+          unless compiling?
+            t = Time.now.strftime("%Y-%m-%d %H:%M:%S")
+            n = modified.length + added.length + removed.length
+            puts "[#{t}] regeneration: #{n = modified.length + added.length + removed.length} files changed"
+            process(site)
+            @files = ::Dir[@path + "/**/*"].inspect
+          end
         end
+        listener.start
       end
     end
 

--- a/lib/rack/jekyll.rb
+++ b/lib/rack/jekyll.rb
@@ -87,12 +87,12 @@ module Rack
       end
     end
 
-    def render_wait_page(req)
-        headers ||= {}
-        headers['Content-Length'] = @wait_page.bytesize.to_s
-        headers['Content-Type'] = 'text/html'
-        headers['Connection'] = 'keep-alive'
-        [200, headers, [@wait_page]]
+    def serve_wait_page(req)
+      headers ||= {}
+      headers['Content-Length'] = @wait_page.bytesize.to_s
+      headers['Content-Type'] = 'text/html'
+      headers['Connection'] = 'keep-alive'
+      [200, headers, [@wait_page]]
     end
 
     def call(env)
@@ -100,7 +100,7 @@ module Rack
       @response = Rack::Response.new
       path_info = @request.path_info
       while compiling?
-        return render_wait_page(@request)
+        return serve_wait_page(@request)
       end
 
       @files = ::Dir[@path + "/**/*"].inspect if @files == "[]"

--- a/lib/rack/templates/wait.html
+++ b/lib/rack/templates/wait.html
@@ -1,0 +1,9 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+<head>
+  <meta charset="UTF-8">
+  <title>Rack Jekyll is working</title>
+</head>
+<body>
+  <h1>Hold on! I'm working on rendering that page for you.</h1>
+</body>

--- a/lib/rack/templates/wait.html
+++ b/lib/rack/templates/wait.html
@@ -1,9 +1,48 @@
 <!DOCTYPE HTML>
 <html lang="en-US">
 <head>
-  <meta charset="UTF-8">
-  <title>Rack Jekyll is working</title>
+  <meta charset="UTF-8"/>
+  <meta http-equiv="refresh" content="60"/>
+  <title>Jekyll is working</title>
+  <style type="text/css">
+    html {
+      position: relative;
+      min-height: 100%;
+    }
+
+    body {
+      font-family: "Liberation Sans", Tahoma, Geneva, "Helvetica Neue", Helvetica, Arial, sans-serif;
+      background-color: #555;
+      background-image: linear-gradient(to bottom, #555 0%, #333 100%);
+      background-repeat: repeat-x;
+    }
+
+    div#message {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+
+      background-color: #c00;
+      background-image: linear-gradient(to bottom, #a70000 0%, #7d0000 100%);
+      background-repeat: repeat-x;
+
+      border-color: #730000;
+      border-radius: 5px;
+
+      color: #fff;
+      padding: 15px;
+    }
+
+    div#message h1 {
+      margin-top: 5px;
+      margin-bottom: 5px;
+    }
+  </style>
 </head>
 <body>
-  <h1>Hold on! I'm working on rendering that page for you.</h1>
+  <div id="message">
+    <h1>Jekyll is currently rendering the site.</h1>
+    <h1>Please try again shortly.</h1>
+  </div>
 </body>


### PR DESCRIPTION
I use rack-jekyll on [Openshift](http://www.openshift.com) and currently when I upload changes to Openshift, it restarts Rack.  During site rendering, Rack responds to any requests with a 503 making people think that the site is down or broken.  This patch shows a simple page to the user during the rendering process to tell them to check back shortly.

The page that is displayed (I called it the "wait page") can be specified by Rack-Jekyll users if they don't like the default one.

I also fixed an issue with "auto".  The Listen object was not being started so it wasn't working.