### PR TITLE
Do not rebuild existing site by default; provide option

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -50,13 +50,18 @@ You need to generate pages and git-add pages and git-commit before you deploy yo
 
 ## Initialization Options
 
-    :config               - use custom config file (default: "_config.yml")
-    :destination          - use custom destination path (default: "_site")
+    :config        - use given config file (default: "_config.yml")
+    :destination   - use given destination path (default: "_site")
+    :force_build   - whether to always generate the site at startup, even
+                     when the destination path is not empty (default: false)
 
 
 *Example:*
 
     run Rack::Jekyll.new(:destination => "mysite")
+
+Note that on read-only filesystems (like e.g. Heroku) a site build will fail,
+so do not set `:force_build => true` in these cases.
 
 
 ## YAML Config
@@ -67,6 +72,7 @@ rack-jekyll now can read the destination path from the `_config.yml` file. Read 
 ## 404 page
 
 You can create a new file: `404.html` with YAML Front Matter. See my [Heroku Demo 404](http://bry4n.heroku.com/show/me/404/).
+
 
 ## Contributors
 
@@ -79,6 +85,7 @@ You can create a new file: `404.html` with YAML Front Matter. See my [Heroku Dem
 * bemurphy (Brendon Murphy)
 * imajes (James Cox)
 * mattr- (Matt Rogers)
+
 
 ## Contribution
 

--- a/lib/rack/jekyll.rb
+++ b/lib/rack/jekyll.rb
@@ -12,6 +12,7 @@ module Rack
 
     def initialize(opts = {})
       @compiling = false
+      @force_build = opts.fetch(:force_build, false)
 
       config_file = opts[:config] || "_config.yml"
       if ::File.exist?(config_file)
@@ -26,9 +27,12 @@ module Rack
       options = ::Jekyll.configuration(opts)
       site = ::Jekyll::Site.new(options)
 
-      @compiling = true
-      site.process
-      @compiling = false
+      if ::Dir[@path + "/**/*"].empty? || @force_build
+        @compiling = true
+        puts "Generating site: #{options['source']} -> #{@path}"
+        site.process
+        @compiling = false
+      end
 
       if options['auto']
         require 'listen'


### PR DESCRIPTION
cc @adaoraul @mattr- opinions?

This addresses #34. I suggest a bug fix release `0.4.2` after possible merge.

Restore the behavior of the previous released version (0.4.1)
and do not always generate the Jekyll site at startup, because
this fails on read-only file systems.

By default, the site is now only generated when the destination path
is empty. This reverts a behavior change introduced with 1088b1b.
(Also provide a configuration option to force a build at startup.)

_Update:_

To clarify: the revert, i.e. *not* to (re)build an existing site, is meant as a **temporary** change, only for a **bug-fix** version **0.4.2**.

For an upcoming version **0.5.0** I propose to adopt the behavior of Jekyll, i.e. always (re)build the site, unless an option is set to skip the initial build (`:skip_initial_build` - this would match the command line flag `--skip-initial-build` for the `jekyll build` command).

