### PR TITLE
Temporarily serve a page while the site is rendering.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -62,6 +62,7 @@ Additional Rack-Jekyll initialization options:
     :force_build   - whether to always generate the site at startup, even
                      when the destination path is not empty (default: false)
     :auto          - whether to watch for changes and rebuild (default: false)
+    :wait_page     - a page to display while pages are rendering
 
 Note that on read-only filesystems a site build will fail,
 so do not set `:force_build => true` in these cases.
@@ -71,6 +72,22 @@ so do not set `:force_build => true` in these cases.
 
 In your site's root directory you can provide a custom `404.html` file
 with YAML front matter.
+
+
+## Wait page
+
+You can create a custom HTML page to display while Jekyll is rendering the
+site.  Set the `:wait_page` initialization option to point to a file relative
+to the root of your Jekyll project.
+
+*Example:*
+
+    run Rack::Jekyll.new(:wait_page => "hold_on.html")
+
+Note that this page should be self-contained (no links to external CSS
+or JS).  It is also not a bad idea to add a `<meta http-equiv="refresh"
+content="60"/>` to the `head` section so that the page will periodically
+refresh itself and display the site once Jekyll has finished rendering.
 
 
 ## Contributing

--- a/lib/rack/jekyll.rb
+++ b/lib/rack/jekyll.rb
@@ -30,6 +30,7 @@ module Rack
       @force_build = overrides.fetch(:force_build, false)
       @auto        = overrides.fetch(:auto, false)
       @wait_page   = read_wait_page(overrides)
+      @compile_queue = Queue.new
 
       overrides.delete(:force_build)
       overrides.delete(:auto)
@@ -107,14 +108,13 @@ module Rack
     end
 
     def compiling?
-      !(@compile_queue.nil? || @compile_queue.empty?)
+      !@compile_queue.empty?
     end
 
     private
 
     def process(message = nil)
       puts message if message
-      @compile_queue = Queue.new
       @compile_queue << '.'
 
       Thread.new do

--- a/lib/rack/templates/wait.html
+++ b/lib/rack/templates/wait.html
@@ -1,0 +1,48 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+<head>
+  <meta charset="UTF-8"/>
+  <meta http-equiv="refresh" content="60"/>
+  <title>Jekyll is working</title>
+  <style type="text/css">
+    html {
+      position: relative;
+      min-height: 100%;
+    }
+
+    body {
+      font-family: "Liberation Sans", Tahoma, Geneva, "Helvetica Neue", Helvetica, Arial, sans-serif;
+      background-color: #555;
+      background-image: linear-gradient(to bottom, #555 0%, #333 100%);
+      background-repeat: repeat-x;
+    }
+
+    div#message {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+
+      background-color: #c00;
+      background-image: linear-gradient(to bottom, #a70000 0%, #7d0000 100%);
+      background-repeat: repeat-x;
+
+      border-color: #730000;
+      border-radius: 5px;
+
+      color: #fff;
+      padding: 15px;
+    }
+
+    div#message h1 {
+      margin-top: 5px;
+      margin-bottom: 5px;
+    }
+  </style>
+</head>
+<body>
+  <div id="message">
+    <h1>Jekyll is currently rendering the site.</h1>
+    <h1>Please try again shortly.</h1>
+  </div>
+</body>

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -47,6 +47,9 @@ def rack_jekyll(options = {})
   jekyll = nil
   silence_output do
     jekyll = Rack::Jekyll.new(options)
+    while jekyll.compiling?
+      sleep 0.4
+    end
   end
 
   jekyll

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -77,6 +77,16 @@ describe "when configuring site" do
       jekyll = rack_jekyll_without_build(:force_build => "ok")
       jekyll.config.wont_include "force_build"
     end
+
+    it ":wait_page is not passed on to Jekyll" do
+      jekyll = rack_jekyll_without_build(:wait_page => "foobar")
+      jekyll.config.wont_include "wait_page"
+    end
+
+    it ":wait_page uses default" do
+      jekyll = rack_jekyll_without_build(:wait_page => "/does/not/exist")
+      jekyll.wait_page.must_match %r{Please try again shortly}
+    end
   end
 
   describe "when initialization options are given and a config file exists" do


### PR DESCRIPTION
In environments like OpenShift, Rack starts before the site is rendered.
The 'wait_page' feature allows Rack to serve an attractive page while
rendering progresses letting the user know that they should check back
soon instead of a generic error page with minimal information.