### PR TITLE
Add the posibility to access a page without .html

### DIFF
--- a/lib/rack/jekyll.rb
+++ b/lib/rack/jekyll.rb
@@ -73,7 +73,7 @@ module Rack
       request = Rack::Request.new(env)
 
       uri = request.path_info
-      if (uri.include? ".")
+      if (uri.include? "." || uri == "/")
         filename = @files.get_filename(uri)
       else
         filename = @files.get_filename(uri << ".html")

--- a/lib/rack/jekyll.rb
+++ b/lib/rack/jekyll.rb
@@ -72,7 +72,12 @@ module Rack
 
       request = Rack::Request.new(env)
 
-      filename = @files.get_filename(request.path_info)
+      uri = request.path_info
+      if (uri.include? ".")
+        filename = @files.get_filename(uri)
+      else
+        filename = @files.get_filename(uri << ".html")
+      end
 
       if filename
         media_type = Utils.media_type(filename)

--- a/lib/rack/jekyll.rb
+++ b/lib/rack/jekyll.rb
@@ -73,7 +73,7 @@ module Rack
       request = Rack::Request.new(env)
 
       uri = request.path_info
-      if (uri.include? "." || uri == "/")
+      if (uri.include? "." or uri == "/")
         filename = @files.get_filename(uri)
       else
         filename = @files.get_filename(uri << ".html")


### PR DESCRIPTION
When the user try to access a page without .html it gets an error because it search directly into the filesystem for the file with that name.

So, now if there are no .html, .css, .js, .<something> in the end of the url it'll add .html to get the right file.