### PR TITLE
Fix rack-jekyll from hanging on the wait page when rendering fails

### DIFF
--- a/lib/rack/jekyll.rb
+++ b/lib/rack/jekyll.rb
@@ -118,9 +118,15 @@ module Rack
       @compile_queue << '.'
 
       Thread.new do
-        @site.process
-        @files.update
-        @compile_queue.clear
+        begin
+          @site.process
+          @files.update
+        rescue => e
+          puts("Jekyll failed to build: #{e}")
+          puts(e.backtrace.join("\n"))
+        ensure
+          @compile_queue.clear
+        end
       end
     end
 

--- a/lib/rack/jekyll.rb
+++ b/lib/rack/jekyll.rb
@@ -75,7 +75,7 @@ module Rack
     def call(env)
       request = Rack::Request.new(env)
 
-      while compiling?
+      if compiling?
         return serve_wait_page(request)
       end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -47,8 +47,10 @@ def rack_jekyll(options = {})
   jekyll = nil
   silence_output do
     jekyll = Rack::Jekyll.new(options)
-    while jekyll.compiling?
-      sleep 0.4
+    jekyll.mutex.synchronize do
+      unless jekyll.complete?
+        jekyll.building_cond.wait(jekyll.mutex)
+      end
     end
   end
 


### PR DESCRIPTION
This PR fixes an issue I discovered where rack-jekyll serves the "wait page" indefinitely because the thread in charge of rendering the site died before it could alert the main thread that its work is complete.
