### PR TITLE
Fix retrieving url encoded file names

### DIFF
--- a/lib/rack/jekyll/filehandler.rb
+++ b/lib/rack/jekyll/filehandler.rb
@@ -22,7 +22,8 @@ module Rack
       # Returns the full file system path of the file corresponding to
       # the given URL path, or +nil+ if no corresponding file exists.
       def get_filename(path)
-        fullpath = ::File.join(@root, path)
+        url_decoded_path = Rack::Utils.unescape(path)
+        fullpath = ::File.join(@root, url_decoded_path)
 
         if fullpath.end_with?("/")
           normalized = fullpath + "index.html"

--- a/test/test_filehandler.rb
+++ b/test/test_filehandler.rb
@@ -12,7 +12,9 @@ describe Rack::Jekyll::FileHandler do
         "/site/README",
         "/site/dir-with-index/index.html",
         "/site/dir-without-index/page.html",
-        "/site/dir1/dir2/dir3/index.html"
+        "/site/dir1/dir2/dir3/index.html",
+        "/site/spaced file.html",
+        "/site/buenos_días.html"
       ]
       @filehandler = Rack::Jekyll::FileHandler.new("/site", files)
     end
@@ -53,6 +55,22 @@ describe Rack::Jekyll::FileHandler do
 
     it "should return nil for directory without index" do
       @filehandler.get_filename("/dir-without-index").must_be_nil
+    end
+
+    it "should return path for file with a space" do
+      @filehandler.get_filename("/spaced file.html").must_equal "/site/spaced file.html"
+    end
+
+    it "should return path for file with a URL encoded space" do
+      @filehandler.get_filename("/spaced%20file.html").must_equal "/site/spaced file.html"
+    end
+
+    it "should return path for file with a special character" do
+      @filehandler.get_filename("/buenos_días.html").must_equal "/site/buenos_días.html"
+    end
+
+    it "should return path for file with a URL special character" do
+      @filehandler.get_filename("/buenos_d%C3%ADas.html").must_equal "/site/buenos_días.html"
     end
   end
 


### PR DESCRIPTION
The file handler was attempting to find a file called "spaced%20file.html", which is not what is stored in the `@files` array. Decoding that gives us back "spaced file.html" and allows it to be found again.

Fixes https://github.com/adaoraul/rack-jekyll/issues/45