### PR TITLE
Match the current behavior of "jekyll serve" and always build the site initially

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -58,14 +58,14 @@ for more settings.
 
 Additional Rack-Jekyll initialization options:
 
-    :config        - use given config file (default: "_config.yml")
-    :force_build   - whether to always generate the site at startup, even
-                     when the destination path is not empty (default: false)
-    :auto          - whether to watch for changes and rebuild (default: false)
-    :wait_page     - a page to display while pages are rendering
+    :config               - use given config file (default: "_config.yml")
+    :skip_initial_build   - whether to skip generating the site at startup, even
+                            when the destination path is empty (default: false)
+    :auto                 - whether to watch for changes and rebuild (default: false)
+    :wait_page            - a page to display while pages are rendering
 
 Note that on read-only filesystems a site build will fail,
-so do not set `:force_build => true` in these cases.
+so set `:skip_initial_build => true` in these cases.
 
 
 ## 404 page

--- a/features/step_definitions/rack_jekyll_steps.rb
+++ b/features/step_definitions/rack_jekyll_steps.rb
@@ -6,8 +6,7 @@ Before do
   FileUtils.mkdir_p(SOURCE_DIR)  unless File.exist?(SOURCE_DIR)
   FileUtils.mkdir_p(DEST_DIR)    unless File.exist?(DEST_DIR)
 
-  @jekyll = Rack::Jekyll.new(:force_build => true,
-                             :source      => SOURCE_DIR,
+  @jekyll = Rack::Jekyll.new(:source      => SOURCE_DIR,
                              :destination => DEST_DIR)
 end
 

--- a/lib/rack/jekyll.rb
+++ b/lib/rack/jekyll.rb
@@ -37,13 +37,13 @@ module Rack
     # Other options are passed on to Jekyll::Site.
     def initialize(options = {})
       overrides = options.dup
-      @force_build   = overrides.fetch(:force_build, false)
-      @auto          = overrides.fetch(:auto, false)
-      @wait_page     = read_wait_page(overrides)
-      @mutex         = Mutex.new
-      @building_cond = ConditionVariable.new
+      @skip_initial_build = overrides.fetch(:skip_initial_build, false)
+      @auto               = overrides.fetch(:auto, false)
+      @wait_page          = read_wait_page(overrides)
+      @mutex              = Mutex.new
+      @building_cond      = ConditionVariable.new
 
-      overrides.delete(:force_build)
+      overrides.delete(:skip_initial_build)
       overrides.delete(:auto)
       overrides.delete(:wait_page)
       @config = ::Jekyll.configuration(overrides)
@@ -54,7 +54,7 @@ module Rack
       @files = FileHandler.new(@destination)
       @site = ::Jekyll::Site.new(@config)
 
-      if @files.empty? || @force_build
+      unless @skip_initial_build
         process("Generating site: #{@source} -> #{@destination}")
       else
         mutex.synchronize do

--- a/lib/rack/jekyll.rb
+++ b/lib/rack/jekyll.rb
@@ -27,8 +27,8 @@ module Rack
     #
     # +:config+::      use given config file (default: "_config.yml")
     #
-    # +:force_build+:: whether to always generate the site at startup, even
-    #                  when the destination path is not empty (default: +false+)
+    # +:skip_initial_build+:: whether to skip generating the site at startup, even
+    #                         if the destination path is empty (default: +false+)
     #
     # +:auto+::        whether to watch for changes and rebuild (default: +false+)
     #

--- a/test/test_build.rb
+++ b/test/test_build.rb
@@ -27,19 +27,20 @@ describe "when initializing a Rack::Jekyll instance" do
       FileUtils.touch(@fake_page)
     end
 
-    it "should not build the site by default" do
+    it "should build the site by default" do
       file_wont_exist(@page)
       rack_jekyll(:source      => @sourcedir,
                   :destination => @destdir)
-      file_wont_exist(@page)
+      file_must_exist(@page)
     end
 
-    it "should build the site when :force_build option is set" do
+    it "should build the site unless :skip_initial_build option is set" do
       file_wont_exist(@page)
-      rack_jekyll(:force_build => true,
+      rack_jekyll(:skip_initial_build => true,
                   :source      => @sourcedir,
                   :destination => @destdir)
-      file_must_exist(@page)
+      file_wont_exist(@page)
+
     end
   end
 

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -73,9 +73,9 @@ describe "when configuring site" do
       jekyll.config.wont_include "auto"
     end
 
-    it ":force_build is not passed on to Jekyll" do
-      jekyll = rack_jekyll_without_build(:force_build => "ok")
-      jekyll.config.wont_include "force_build"
+    it ":skip_initial_build is not passed on to Jekyll" do
+      jekyll = rack_jekyll_without_build(:skip_initial_build => "ok")
+      jekyll.config.wont_include "skip_initial_build"
     end
 
     it ":wait_page is not passed on to Jekyll" do

--- a/test/test_requests.rb
+++ b/test/test_requests.rb
@@ -15,8 +15,7 @@ describe "when handling requests" do
     FileUtils.mkdir_p(@sourcedir)  unless File.exist?(@sourcedir)
     FileUtils.mkdir_p(@destdir)    unless File.exist?(@destdir)
 
-    @jekyll = rack_jekyll(:force_build => true,
-                          :source      => @sourcedir,
+    @jekyll = rack_jekyll(:source      => @sourcedir,
                           :destination => @destdir)
     @request = Rack::MockRequest.new(@jekyll)
   end
@@ -97,8 +96,7 @@ describe "when handling requests" do
           # Theoretically, if the site rendered fast enough, the request
           # would end up getting actual content instead of the wait page
           # and this test would fail.
-          jekyll = Rack::Jekyll.new(:force_build => true,
-                                    :source      => @sourcedir,
+          jekyll = Rack::Jekyll.new(:source      => @sourcedir,
                                     :destination => @destdir,
                                     :wait_page   => filename)
         end
@@ -127,8 +125,7 @@ describe "when handling requests" do
 
         jekyll = nil
         silence_output do
-          jekyll = Rack::Jekyll.new(:force_build => true,
-                                    :source      => sourcedir,
+          jekyll = Rack::Jekyll.new(:source      => sourcedir,
                                     :destination => destdir,
                                     :wait_page   => filename)
         end
@@ -210,8 +207,7 @@ describe "when handling requests" do
         filename = File.join(@sourcedir, "404.html")
         File.open(filename, "w") {|f| f.puts "Custom 404" }
 
-        jekyll = rack_jekyll(:force_build => true,
-                             :source      => @sourcedir,
+        jekyll = rack_jekyll(:source      => @sourcedir,
                              :destination => @destdir)
         request = Rack::MockRequest.new(jekyll)
 


### PR DESCRIPTION
Fixes https://github.com/adaoraul/rack-jekyll/issues/40:

> Change startup behavior (of Rack::Jekyll.new):
>
> Adopt the current behavior of Jekyll (the "jekyll serve" command) and always build the site initially.
> Add an option to skip the initial build (e.g. :skip_initial_build - this would match Jekyll's command line flag --skip-initial-build).
> The option is necessary for deploys on read-only filesystems, where the pre-built site already exists. (The current :force_build option, which is only available since 0.4.2, will be obsolete.)

Invert force_build into skip_initial_build